### PR TITLE
feat: add PostgreSQL support, Docker deployment, and health checks (#48)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+**/.git
+**/bin
+**/obj
+**/.vs
+**/.vscode
+**/.idea
+*.db
+*.db-shm
+*.db-wal
+.env
+.env.*
+!.env.example

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+POSTGRES_PASSWORD=change_me_to_secure_password

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ appsettings.*.local.json
 *.db
 *.db-shm
 *.db-wal
+
+## Environment
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+
+COPY KanbanApp/KanbanApp.csproj KanbanApp/
+RUN dotnet restore KanbanApp/KanbanApp.csproj
+
+COPY . .
+RUN dotnet publish KanbanApp/KanbanApp.csproj -c Release -o /app/publish
+
+FROM mcr.microsoft.com/dotnet/aspnet:8.0
+WORKDIR /app
+COPY --from=build /app/publish .
+
+EXPOSE 8080
+ENV ASPNETCORE_URLS=http://+:8080
+
+ENTRYPOINT ["dotnet", "KanbanApp.dll"]

--- a/KanbanApp/KanbanApp.csproj
+++ b/KanbanApp/KanbanApp.csproj
@@ -13,6 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.11" />
     <PackageReference Include="MudBlazor" Version="8.15.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
   </ItemGroup>

--- a/KanbanApp/Migrations/20260217163440_InitialCreate.cs
+++ b/KanbanApp/Migrations/20260217163440_InitialCreate.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
@@ -18,6 +19,7 @@ namespace KanbanApp.Migrations
                 columns: table => new
                 {
                     Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn)
                         .Annotation("Sqlite:Autoincrement", true),
                     Name = table.Column<string>(type: "TEXT", maxLength: 200, nullable: false),
                     Description = table.Column<string>(type: "TEXT", maxLength: 1000, nullable: true),
@@ -33,6 +35,7 @@ namespace KanbanApp.Migrations
                 columns: table => new
                 {
                     Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn)
                         .Annotation("Sqlite:Autoincrement", true),
                     Name = table.Column<string>(type: "TEXT", maxLength: 100, nullable: false),
                     Color = table.Column<string>(type: "TEXT", maxLength: 50, nullable: true)
@@ -47,6 +50,7 @@ namespace KanbanApp.Migrations
                 columns: table => new
                 {
                     Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn)
                         .Annotation("Sqlite:Autoincrement", true),
                     Name = table.Column<string>(type: "TEXT", maxLength: 200, nullable: false),
                     Color = table.Column<string>(type: "TEXT", maxLength: 50, nullable: true),
@@ -70,6 +74,7 @@ namespace KanbanApp.Migrations
                 columns: table => new
                 {
                     Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn)
                         .Annotation("Sqlite:Autoincrement", true),
                     Title = table.Column<string>(type: "TEXT", maxLength: 500, nullable: false),
                     Description = table.Column<string>(type: "TEXT", maxLength: 4000, nullable: true),
@@ -96,6 +101,7 @@ namespace KanbanApp.Migrations
                 columns: table => new
                 {
                     Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn)
                         .Annotation("Sqlite:Autoincrement", true),
                     Text = table.Column<string>(type: "TEXT", maxLength: 500, nullable: false),
                     IsDone = table.Column<bool>(type: "INTEGER", nullable: false, defaultValue: false),

--- a/KanbanApp/Program.cs
+++ b/KanbanApp/Program.cs
@@ -13,8 +13,14 @@ builder.Services.AddRazorComponents()
 
 builder.Services.AddMudServices();
 
-builder.Services.AddDbContext<AppDbContext>(options =>
-    options.UseSqlite(builder.Configuration.GetConnectionString("DefaultConnection")));
+// Database provider selection via DB_PROVIDER environment variable
+var dbProvider = builder.Configuration["DB_PROVIDER"] ?? "sqlite";
+var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
+
+if (dbProvider == "postgres")
+    builder.Services.AddDbContext<AppDbContext>(options => options.UseNpgsql(connectionString));
+else
+    builder.Services.AddDbContext<AppDbContext>(options => options.UseSqlite(connectionString));
 
 builder.Services.AddScoped<IBoardService, BoardService>();
 builder.Services.AddScoped<IColumnService, ColumnService>();
@@ -23,21 +29,31 @@ builder.Services.AddScoped<BoardFilterState>();
 builder.Services.AddScoped<INotificationService, NotificationService>();
 builder.Services.AddScoped<IExportService, ExportService>();
 
+builder.Services.AddHealthChecks()
+    .AddDbContextCheck<AppDbContext>();
+
 var app = builder.Build();
 
 // Auto-apply pending migrations at startup
 using (var scope = app.Services.CreateScope())
 {
     var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
-    try
+    if (dbProvider == "postgres")
     {
         db.Database.Migrate();
     }
-    catch (Microsoft.Data.Sqlite.SqliteException)
+    else
     {
-        // Database file exists but has no migration history — recreate it
-        db.Database.EnsureDeleted();
-        db.Database.Migrate();
+        try
+        {
+            db.Database.Migrate();
+        }
+        catch (Microsoft.Data.Sqlite.SqliteException)
+        {
+            // Database file exists but has no migration history — recreate it
+            db.Database.EnsureDeleted();
+            db.Database.Migrate();
+        }
     }
 }
 
@@ -52,6 +68,8 @@ if (!app.Environment.IsDevelopment())
 
 app.UseStaticFiles();
 app.UseAntiforgery();
+
+app.MapHealthChecks("/healthz");
 
 app.MapRazorComponents<App>()
     .AddInteractiveServerRenderMode();

--- a/KanbanApp/appsettings.Production.json
+++ b/KanbanApp/appsettings.Production.json
@@ -1,0 +1,11 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "${DB_CONNECTION_STRING}"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,76 @@
+# KanbanApp
+
+Blazor Server application for managing kanban boards, built with .NET 8 and MudBlazor.
+
+## Development
+
+```bash
+cd KanbanApp
+dotnet run
+```
+
+By default, the app uses SQLite (`kanban-dev.db` in Development, `kanban.db` otherwise).
+
+## Deployment
+
+### Docker Compose (recommended)
+
+1. Copy the environment file and set a secure password:
+
+```bash
+cp .env.example .env
+# Edit .env and set POSTGRES_PASSWORD
+```
+
+2. Start the application:
+
+```bash
+docker-compose up -d
+```
+
+The app will be available at `http://localhost:8080`.
+
+PostgreSQL data is persisted in the `pgdata` Docker volume.
+
+### Environment variables
+
+| Variable | Description | Default |
+|---|---|---|
+| `DB_PROVIDER` | Database provider: `sqlite` or `postgres` | `sqlite` |
+| `ConnectionStrings__DefaultConnection` | Database connection string | `Data Source=kanban.db` |
+| `ASPNETCORE_ENVIRONMENT` | Runtime environment | `Production` |
+| `POSTGRES_PASSWORD` | PostgreSQL password (docker-compose) | — |
+
+### Database providers
+
+The app supports two database providers, selectable via `DB_PROVIDER`:
+
+- **sqlite** (default) — zero-config, file-based. Good for development and single-server deployments.
+- **postgres** — PostgreSQL 16+. Recommended for production.
+
+Example PostgreSQL connection string:
+```
+Host=localhost;Database=kanban;Username=kanban;Password=secret
+```
+
+### Migrations
+
+Migrations are applied automatically at startup (`db.Database.Migrate()`). The migration is compatible with both SQLite and PostgreSQL providers.
+
+### Health check
+
+The `/healthz` endpoint returns the application health status, including database connectivity.
+
+```bash
+curl http://localhost:8080/healthz
+```
+
+### Manual Docker build
+
+```bash
+docker build -t kanban-app .
+docker run -p 8080:8080 \
+  -e DB_PROVIDER=postgres \
+  -e "ConnectionStrings__DefaultConnection=Host=db;Database=kanban;Username=kanban;Password=secret" \
+  kanban-app
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+services:
+  app:
+    build: .
+    ports:
+      - "8080:8080"
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Production
+      - DB_PROVIDER=postgres
+      - ConnectionStrings__DefaultConnection=Host=db;Database=kanban;Username=kanban;Password=${POSTGRES_PASSWORD}
+    depends_on:
+      db:
+        condition: service_healthy
+    restart: unless-stopped
+
+  db:
+    image: postgres:16-alpine
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_DB=kanban
+      - POSTGRES_USER=kanban
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U kanban"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+volumes:
+  pgdata:


### PR DESCRIPTION
- Add multi-provider DB selection via DB_PROVIDER env var (sqlite/postgres)
- Update EF Core migration with Npgsql annotations for dual-provider compatibility
- Add auto-migrate at startup for both providers
- Create multi-stage Dockerfile (SDK → runtime)
- Create docker-compose.yml with app + postgres:16-alpine and persistent volume
- Add /healthz health check endpoint with EF Core DB connectivity check
- Add appsettings.Production.json with connection string placeholder
- Add .env.example, .dockerignore, and README.md with deployment instructions

https://claude.ai/code/session_016XYWQ8nqsJdeMiHmTJuoGY